### PR TITLE
Fix assertion numbering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ export const test = Object.assign(function test(name: string, fn: (t: Assertions
 	}
 });
 
-let i = 0;
+let testIndex = 0;
+let assertIndex = 0;
 let running = false;
 
 export type Assertions = {
@@ -63,11 +64,12 @@ let skipped = 0;
 const isNode = typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]';
 
 function logResult(ok: boolean, operator: string, msg: string, info: { actual?: any, expected?: any } = {}) {
+	assertIndex += 1;
 	if (ok) {
-		console.log(`ok ${i} — ${msg}`);
+		console.log(`ok ${assertIndex} — ${msg}`);
 		passed += 1;
 	} else {
-		console.log(`not ok ${i} — ${msg}`);
+		console.log(`not ok ${assertIndex} — ${msg}`);
 		failed += 1;
 
 		console.log('  ---');
@@ -156,7 +158,7 @@ export const assert: Assertions = {
 };
 
 async function dequeue() {
-	const test = tests[i++];
+	const test = tests[testIndex++];
 
 	if (test) {
 		if (!test.shouldRun) {
@@ -174,7 +176,7 @@ async function dequeue() {
 			await test.fn(assert);
 		} catch (err) {
 			failed += 1;
-			console.log(`not ok ${i} — ${err.message}`);
+			console.log(`not ok ${assertIndex} — ${err.message}`);
 			console.error(`  ${err.stack.replace(/^\s+/gm, '    ')}`);
 		}
 


### PR DESCRIPTION
In TAP, each assertion is counted on its own rather than as being part
of a larger test. tape-modern was printing the numbers of the `test()`
calls though.

Previously, assertions were logged with the index of their surrounding
`test()` call. If you use multiple asserts in a single test, you get
output like:

```
ok 1 description
ok 1 description
ok 1 description

1..3
```

This would be interpreted as a failed test by compliant TAP parsers,
because the planning line lists different test numbers than the test
lines do.

With this patch, the output is:

```
ok 1 description
ok 2 description
ok 3 description

1..3
```